### PR TITLE
Complete certificates data loading and modal

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -217,17 +217,20 @@ const togglePortfolioModal = () => {
 };
 
 // Build media element (image or video)
-function buildMediaEl(type, src) {
+function buildMediaEl(type, src, altText) {
   if (type === "video") {
     const v = document.createElement("video");
     v.src = src;
     v.controls = true;
     v.playsInline = true;
+    if (altText) {
+      v.setAttribute("aria-label", altText);
+    }
     return v;
   } else {
     const img = document.createElement("img");
     img.src = src;
-    img.alt = "project media";
+    img.alt = altText || "project media";
     img.loading = "lazy";
     return img;
   }
@@ -251,7 +254,7 @@ function renderPortfolioGallery(title, desc, mediaList) {
 
   // set main
   const first = mediaList[0];
-  portfolioModalMain.appendChild(buildMediaEl(first.type, first.src));
+  portfolioModalMain.appendChild(buildMediaEl(first.type, first.src, first.alt));
 
   // thumbs
   mediaList.forEach((m, idx) => {
@@ -260,12 +263,12 @@ function renderPortfolioGallery(title, desc, mediaList) {
     btn.setAttribute("type", "button");
     btn.addEventListener("click", () => {
       portfolioModalMain.innerHTML = "";
-      portfolioModalMain.appendChild(buildMediaEl(m.type, m.src));
+      portfolioModalMain.appendChild(buildMediaEl(m.type, m.src, m.alt));
     });
     if (m.type === "image") {
       const thumb = document.createElement("img");
       thumb.src = m.src;
-      thumb.alt = "thumb";
+      thumb.alt = m.alt || "thumb";
       btn.appendChild(thumb);
     } else {
       // simple placeholder for video thumb: use <img> if poster available later
@@ -285,14 +288,21 @@ function extractMediaFromProject(projectItem) {
   const img = projectItem.querySelector(".project-img img");
   if (img && img.getAttribute("src")) {
     const src = img.getAttribute("src").trim();
-    if (src) media.push({ type: "image", src });
+    if (src) media.push({ type: "image", src, alt: img.getAttribute("alt") || "" });
   }
   // 2) Read hidden extras: .project-media > [data-type][data-src]
   const extras = projectItem.querySelectorAll(".project-media [data-src]");
   extras.forEach(el => {
     const type = (el.getAttribute("data-type") || "image").toLowerCase();
     const src = el.getAttribute("data-src") || "";
-    if (src) media.push({ type, src });
+    if (src) {
+      media.push({
+        type,
+        src,
+        alt: el.getAttribute("data-alt") || "",
+        poster: el.getAttribute("data-poster") || ""
+      });
+    }
   });
   return media;
 }
@@ -370,10 +380,17 @@ function renderCertificateGallery(title, desc, media) {
 
   // set main
   const first = media;
-  certificateModalMain.appendChild(buildMediaEl(first.type, first.src));
+  if (!first || !first.src) {
+    const empty = document.createElement("div");
+    empty.textContent = "No media available for this certificate.";
+    certificateModalMain.appendChild(empty);
+    return;
+  }
+
+  certificateModalMain.appendChild(buildMediaEl(first.type || "image", first.src, first.alt));
 }
 
-const certificateList = document.querySelector("[data-certificate-list]") || document.querySelector(".certificates .certificate-list");
+const certificateList = document.querySelector("[data-certificates-list]");
 
 const activateCertificates = (item, ev) => {
   if (ev) {
@@ -391,11 +408,15 @@ const activateCertificates = (item, ev) => {
   const title = titleEl ? titleEl.textContent.trim() : "Certificate";
   const desc = descEl ? descEl.innerHTML : "";
 
-  renderCertificateGallery(title, desc, { type: "image", src: item.dataset.certificateSrc });
+  renderCertificateGallery(title, desc, {
+    type: "image",
+    src: item.dataset.certificateSrc,
+    alt: item.dataset.certificateAlt
+  });
   toggleCertificateModal();
 };
 
-if (certificateList) {
+if (certificateList && certificateModalContainer && certificateOverlay && certificateCloseBtn) {
   certificateList.addEventListener("click", (event) => {
     const trigger = event.target.closest("[data-certificate-trigger]");
     if (!trigger) return;
@@ -412,8 +433,8 @@ if (certificateList) {
     if (!item) return;
     activateCertificates(item, event);
   });
-}
 
-// Close handlers
-certificateCloseBtn.addEventListener("click", toggleCertificateModal);
-certificateOverlay.addEventListener("click", toggleCertificateModal);
+  // Close handlers
+  certificateCloseBtn.addEventListener("click", toggleCertificateModal);
+  certificateOverlay.addEventListener("click", toggleCertificateModal);
+}

--- a/assets/js/update.js
+++ b/assets/js/update.js
@@ -505,131 +505,67 @@
 
 
   const applyCertificates = (data) => {
-    const forms = Array.isArray(data?.certificate?.forms) ? data.certificate.forms : [];
-    const listEl = document.querySelector("[data-certificate-list]");
-    const categories = new Map();
+    const forms = Array.isArray(data?.certificates?.forms) ? data.certificates.forms : [];
+    const listEl = document.querySelector("[data-certificates-list]");
 
-    if (listEl && ensureTemplate("#certificate-item-template")) {
-      clearChildren(listEl);
-      forms.forEach((form, idx) => {
-        const item = getTemplateClone("#certificate-item-template");
-        if (!item) return;
-        const indexValue = coerceString(form.index || idx + 1);
-        if (indexValue) {
-          item.dataset.projectIndex = indexValue;
-        }
-        const card = item.querySelector(".certificate-card");
-        if (card && indexValue) {
-          card.dataset.projectIndex = indexValue;
-        }
-        const categoryLabel = coerceString(form.category);
-        if (categoryLabel) {
-          const key = categoryLabel.toLowerCase();
-          item.dataset.category = key;
-          const categoryEl = item.querySelector("[data-certificate-category]");
-          setText(categoryEl, categoryLabel);
-          if (!categories.has(key)) {
-            categories.set(key, categoryLabel);
-          }
-        }
-        
-        setText(item.querySelector("[data-certicate-title]"), coerceString(form.title));
-        setHTML(item.querySelector("[data-certificate-description]"), coerceString(form.descriptionHtml));
-        const thumb = form.thumbnail;
-        if (thumb) {
-          const img = item.querySelector("[data-certificate-image]");
-          if (img) {
-            const src = coerceString(thumb.src);
-            const alt = coerceString(thumb.alt);
-            if (src) img.setAttribute("src", src);
-            if (alt) img.setAttribute("alt", alt);
-          }
-        }
-        const mediaContainer = ensureProjectMediaContainer(item);
-        const mediaItems = Array.isArray(project.media) ? project.media : [];
-        mediaItems.forEach(media => {
-          const type = coerceString(media.type || "image").toLowerCase();
-          const src = coerceString(media.src);
-          if (!src) return;
-          const placeholder = document.createElement("span");
-          placeholder.dataset.type = type;
-          placeholder.dataset.src = src;
-          const poster = coerceString(media.poster);
-          if (poster) {
-            placeholder.dataset.poster = poster;
-          }
-          const alt = coerceString(media.alt);
-          if (alt) {
-            placeholder.dataset.alt = alt;
-          }
-          mediaContainer.appendChild(placeholder);
-        });
-        listEl.appendChild(item);
-      });
-      updatePortfolioFilters(categories);
-      return;
-    }
+    if (!listEl || !ensureTemplate("#certificate-item-template")) return;
 
-    projects.forEach(project => {
-      const index = coerceString(project.index);
-      const item = document.querySelector(`[data-project-index="${index}"]`);
+    clearChildren(listEl);
+
+    forms.forEach((form, idx) => {
+      const item = getTemplateClone("#certificate-item-template");
       if (!item) return;
-      const category = coerceString(project.category);
-      if (category) {
-        const key = category.toLowerCase();
-        item.dataset.category = key;
-        if (!categories.has(key)) {
-          categories.set(key, category);
-        }
+
+      const indexValue = coerceString(form.index || idx + 1);
+      if (indexValue) {
+        item.dataset.certificateIndex = indexValue;
       }
-      const link = coerceString(project.link);
+
+      const card = item.querySelector(".certificate-card");
+      if (card && indexValue) {
+        card.dataset.certificateIndex = indexValue;
+      }
+
+      const link = coerceString(form.link);
       if (link) {
-        item.dataset.projectLink = link;
-      } else {
-        delete item.dataset.projectLink;
+        item.dataset.certificateLink = link;
       }
-      const title = coerceString(project.title);
-      setText(item.querySelector("[data-project-title]"), title);
-      const categoryEl = item.querySelector("[data-project-category]");
-      if (categoryEl) {
-        const existing = categoryEl.textContent || "";
-        const nextValue = category || existing;
-        setText(categoryEl, nextValue);
-      }
-      setHTML(item.querySelector("[data-project-description]"), coerceString(project.descriptionHtml));
-      const thumb = project.thumbnail;
-      if (thumb) {
-        const img = item.querySelector("[data-project-image]");
-        if (img) {
-          const src = coerceString(thumb.src);
-          const alt = coerceString(thumb.alt);
-          if (src) img.setAttribute("src", src);
-          if (alt) img.setAttribute("alt", alt);
+
+      const title = coerceString(form.title);
+      setText(item.querySelector("[data-certificate-title]"), title);
+
+      const issuer = coerceString(form.from || form.category);
+      setText(item.querySelector("[data-certificate-category]"), issuer);
+
+      setHTML(item.querySelector("[data-certificate-description]"), coerceString(form.descriptionHtml));
+
+      const image = form?.image || form?.thumbnail || {};
+      const imgEl = item.querySelector("[data-certificate-image]");
+      const src = coerceString(image.src);
+      const alt = coerceString(image.alt) || title || "Certificate";
+
+      if (imgEl) {
+        if (src) {
+          imgEl.setAttribute("src", src);
+          item.dataset.certificateSrc = src;
+          if (card) {
+            card.dataset.certificateSrc = src;
+          }
         }
       }
 
-      const mediaContainer = ensureProjectMediaContainer(item);
-      const mediaItems = Array.isArray(project.media) ? project.media : [];
-      mediaItems.forEach(media => {
-        const type = coerceString(media.type || "image").toLowerCase();
-        const src = coerceString(media.src);
-        if (!src) return;
-        const placeholder = document.createElement("span");
-        placeholder.dataset.type = type;
-        placeholder.dataset.src = src;
-        const poster = coerceString(media.poster);
-        if (poster) {
-          placeholder.dataset.poster = poster;
+      if (alt) {
+        if (imgEl) {
+          imgEl.setAttribute("alt", alt);
         }
-        const alt = coerceString(media.alt);
-        if (alt) {
-          placeholder.dataset.alt = alt;
+        item.dataset.certificateAlt = alt;
+        if (card) {
+          card.dataset.certificateAlt = alt;
         }
-        mediaContainer.appendChild(placeholder);
-      });
+      }
+
+      listEl.appendChild(item);
     });
-
-    updatePortfolioFilters(categories);
   };
 
   const applyContact = (data) => {

--- a/data.json
+++ b/data.json
@@ -328,22 +328,23 @@
       {
         "index": 1,
         "title": "C++ For C Programmers",
-        "from": "Coursera - deeplearning.ai",
+        "from": "Coursera - DeepLearning.AI",
+        "descriptionHtml": "<p>Coverage of modern C++ constructs such as STL containers, iterators, and graph algorithms tailored for students with a C background.</p>",
         "image": {
           "src": "./assets/images/certificate_Cpp.jpg",
-          "alt": "C++ For C Programmers"
+          "alt": "Certificate - C++ For C Programmers"
         }
       },
       {
         "index": 2,
         "title": "Machine Learning with Python",
         "from": "Coursera - IBM",
+        "descriptionHtml": "<p>Hands-on labs with scikit-learn covering supervised and unsupervised learning, model evaluation, and deployment basics.</p>",
         "image": {
           "src": "./assets/images/placeholders/no-image-3x4.svg",
-          "alt": "Machine Learning with Python"
+          "alt": "Certificate - Machine Learning with Python"
         }
       }
-      
     ]
   },
   "contact": {


### PR DESCRIPTION
## Summary
- load certificate entries from `data.json` and hydrate card fields plus modal metadata
- refine certificate modal handling while improving media accessibility across galleries
- extend certificate seed data with issuer details and descriptions

## Testing
- npm run test:portfolio

------
https://chatgpt.com/codex/tasks/task_e_68ddd217aa58833183bd97d343b5acba